### PR TITLE
docs: add Best Practices section to CLAUDE.md with Prettier rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,21 @@ Run a single Playwright test file:
 pnpm test tests/<file>.spec.ts
 ```
 
+## Best Practices
+
+All code must conform to the Prettier configuration in `.prettierrc.json`. Run
+`pnpm format` to check and `pnpm format:fix` to auto-correct before committing.
+Write code that already satisfies these rules to avoid needing repeated fix runs:
+
+- **Trailing commas**: Add trailing commas wherever ES5 allows (objects, arrays,
+  function parameters).
+- **Semicolons**: Always end statements with a semicolon.
+- **Indentation**: Use 2 spaces (no tabs).
+- **Quotes**: Use single quotes in JS/TS (`'value'`). Use single quotes in JSX
+  attributes (`prop='value'`).
+- **Tailwind class order**: Classes are sorted automatically by
+  `prettier-plugin-tailwindcss`; do not manually reorder them.
+
 ## Architecture
 
 This is a **Next.js 15** personal portfolio and blog, using the Pages Router (not App Router). TypeScript, Tailwind CSS, and `pnpm` are standard throughout.


### PR DESCRIPTION
## Summary

Adds a **Best Practices** section to `CLAUDE.md` (between `## Commands` and `## Architecture`) documenting the Prettier rules from `.prettierrc.json`.

## Motivation

`pnpm format:fix` has been needed multiple times to correct recent code changes. Making the formatting rules explicit in `CLAUDE.md` surfaces them at the start of every Claude Code session, so code is written to spec from the start.

## Rules documented

| Rule | Value |
|------|-------|
| `trailingComma` | ES5 — trailing commas in objects, arrays, params |
| `semi` | Always end statements with a semicolon |
| `tabWidth` | 2 spaces |
| `singleQuote` | Single quotes in JS/TS |
| `jsxSingleQuote` | Single quotes in JSX attributes |
| `prettier-plugin-tailwindcss` | Tailwind class order is auto-sorted; don't manually reorder |

## Change type

Documentation only — no code changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)