### PR TITLE
Implement design system: mobile menu, button hover fills, dark mode fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,22 @@ Posts are MDX files with YAML frontmatter (`title`, `publishedOn`, `description`
 - `/pages/api/og.tsx` — dynamic OG image generation
 - `/pages/sitemap.xml.ts` — XML sitemap
 
+### Design System
+
+The visual identity is strictly **black and white** at its core. Key rules:
+
+- **Color palette**: `--foreground` (black/near-white) and `--background` (white/deep-navy) are the only fills. `--primary` (crimson light / sky-blue dark) and `--secondary` (pink) are accent-only — used exclusively for hover underlines and focus states, never as fills or backgrounds.
+- **Typography**: Logo uses Long Cang (`longCang` from `@/components/fonts`). All UI uses Raleway (`raleway`). Blog editorial uses Merriweather. Code uses Noto Sans Mono. Font weight is the primary emphasis tool — `font-light` (300) base with `font-black` (900) on key words.
+- **Headings**: Always `uppercase`, Raleway light with black-weight accents on the emphasized word.
+- **Border radius**: Zero everywhere — flat, square corners throughout.
+- **Borders**: `1px solid currentColor` on cards; `2px solid` on CTA/submit buttons.
+- **Hover states**:
+  - Nav links: 4px underline bar that `scaleX` from left (`WithUnderline` component).
+  - CTA/submit buttons: fill inverts on hover (transparent → `bg-zinc-900`/`bg-foreground`, text flips to contrast).
+  - Logo (footer): dims to `text-foreground/40` — no accent color.
+- **No gradients, no textures, no shadows** in the base theme.
+- **Dark mode**: `next-themes` class-based (`.dark` on `<html>`). Accent flips crimson → sky-blue. Deep navy background (`hsl(220.9, 39.3%, 11%)`).
+
 ### Styling
 
 Tailwind CSS with CSS custom properties for theming (see `globals.css` for `--foreground`, `--background`, `--primary`, `--secondary` tokens). Dark mode uses `next-themes` with class-based switching. Page-specific styles use CSS Modules alongside Tailwind.
@@ -61,6 +77,10 @@ Tailwind CSS with CSS custom properties for theming (see `globals.css` for `--fo
 ### Component Conventions
 
 `/components/elements/` contains thin semantic wrappers (`A`, `P`, `H1`–`H4`, `Pre`, etc.) — use these instead of raw HTML elements in page content. Import paths use the `@/` alias (maps to project root).
+
+- `WithUnderline` — nav link hover effect (4px bar, `scaleX` left→right, 60% opacity).
+- `ContactCTA` — the "Contact" button used in both desktop nav and mobile menu overlay.
+- `MobileMenu` — full-screen overlay triggered by an asymmetric 3-line hamburger (22/16/10px). Dark mode and language toggles live inside the overlay at the bottom, not in the header.
 
 ### External Services
 

--- a/components/contact/cta.tsx
+++ b/components/contact/cta.tsx
@@ -19,8 +19,9 @@ export default function ContactCTA() {
       href={{ pathname, search: '?modal=1' }}
       className={clsx(
         'ml-0 mr-auto border-2 border-zinc-900 p-4 text-lg font-extrabold uppercase text-zinc-900',
+        'transition-colors hover:bg-zinc-900 hover:text-white',
         'lg:mr-0',
-        'dark:border-foreground dark:text-foreground'
+        'dark:border-foreground dark:text-foreground dark:hover:bg-foreground dark:hover:text-background'
       )}
     >
       {t('contact')}

--- a/components/contact/form.tsx
+++ b/components/contact/form.tsx
@@ -95,8 +95,9 @@ export default function ContactForm() {
         disabled={isLoading}
         className={clsx(
           'ml-0 mr-auto flex items-center border-2 border-zinc-900 p-4 text-lg font-extrabold uppercase text-zinc-900',
+          'transition-colors hover:bg-zinc-900 hover:text-white',
           'lg:mr-0',
-          'dark:border-foreground dark:text-foreground'
+          'dark:border-foreground dark:text-foreground dark:hover:bg-foreground dark:hover:text-background'
         )}
       >
         {isLoading && <Spinner />}
@@ -134,7 +135,7 @@ const Input = ({
           'mb-6 w-full border border-zinc-900 p-2 text-foreground',
           'invalid:border-pink-500 invalid:text-pink-600',
           'focus:invalid:border-pink-500 focus:invalid:ring-pink-500',
-          'dark:border-slate-800 dark:bg-white dark:text-black',
+          'dark:border-foreground/30 dark:bg-transparent dark:text-foreground',
           {
             'min-h-44': type === 'textarea',
           }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -16,7 +16,7 @@ export default function Footer() {
 
       <Link
         href='/'
-        className='text-foreground hover:text-primary dark:hover:text-sky-300'
+        className='hover:text-foreground/40 text-foreground transition-colors'
       >
         <Logo />
       </Link>

--- a/components/menu/mobile.tsx
+++ b/components/menu/mobile.tsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid';
 import clsx from 'clsx';
 import useTranslation from 'next-translate/useTranslation';
 import { useEffect, useState } from 'react';
@@ -20,6 +19,8 @@ import { usePathname } from 'next/navigation';
 import { MENU_ITEMS } from '@/lib/data';
 import DarkModeToggle from '@/components/dark-mode-toggle';
 import LanguageToggle from '@/components/language-toggle';
+import Logo from '@/components/logo';
+import ContactCTA from '@/components/contact/cta';
 
 export default function MobileMenu() {
   const [isOpen, setIsOpen] = useState(false);
@@ -30,68 +31,89 @@ export default function MobileMenu() {
     setIsOpen(false);
   }, [pathname]);
 
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
   return (
     <>
-      <LanguageToggle className='ml-auto mr-4 md:hidden' />
-      <DarkModeToggle className='mr-8 md:hidden' />
-
-      <button className='md:hidden' onClick={() => setIsOpen(true)}>
-        <Bars3Icon className='h-6 w-6' />
+      {/* Asymmetric hamburger — three lines of decreasing width */}
+      <button
+        className='flex h-8 w-8 flex-col items-end justify-center gap-[5px] md:hidden'
+        onClick={() => setIsOpen(true)}
+        aria-label={t('openMenu')}
+      >
+        <span className='block h-[2px] w-[22px] bg-foreground transition-colors' />
+        <span className='block h-[2px] w-[16px] bg-foreground transition-colors' />
+        <span className='block h-[2px] w-[10px] bg-foreground transition-colors' />
       </button>
 
+      {/* Full-screen overlay */}
       <div
         className={clsx(
-          'fixed inset-0 z-10 -translate-y-full bg-background transition-transform md:hidden',
-          {
-            'translate-y-0': isOpen,
-          }
+          'fixed inset-0 z-50 flex flex-col bg-background transition-opacity duration-200 md:hidden',
+          isOpen
+            ? 'pointer-events-auto opacity-100'
+            : 'pointer-events-none opacity-0'
         )}
       >
-        <button
-          className='absolute right-0 top-1 p-4'
-          onClick={() => setIsOpen(false)}
-        >
-          <XMarkIcon className='h-6 w-6' />
-        </button>
+        {/* Top row: logo + close */}
+        <div className='flex items-center justify-between p-6'>
+          <Link href='/' onClick={() => setIsOpen(false)}>
+            <Logo />
+          </Link>
 
-        <nav aria-label='Menú Principal' className='flex flex-col gap-4'>
-          <ul className='flex w-full flex-col gap-4 py-3'>
+          <button
+            onClick={() => setIsOpen(false)}
+            aria-label={t('closeMenu')}
+            className='flex items-center justify-center p-1 text-foreground'
+          >
+            <svg
+              width='22'
+              height='22'
+              viewBox='0 0 22 22'
+              fill='none'
+              stroke='currentColor'
+              strokeWidth='2'
+              strokeLinecap='round'
+            >
+              <line x1='3' y1='3' x2='19' y2='19' />
+              <line x1='19' y1='3' x2='3' y2='19' />
+            </svg>
+          </button>
+        </div>
+
+        {/* Nav items */}
+        <nav aria-label={t('mainMenu')} className='flex-1 px-6'>
+          <ul className='flex flex-col'>
             {MENU_ITEMS.map(({ href, key }, index) => (
-              <MenuItem key={index} href={href}>
-                {t(key)}
-              </MenuItem>
+              <li key={index} className='border-foreground/10 border-b'>
+                <Link
+                  href={href}
+                  className='block py-5 text-[28px] font-light uppercase tracking-wide transition-colors'
+                  onClick={() => setIsOpen(false)}
+                >
+                  {t(key)}
+                </Link>
+              </li>
             ))}
-
-            <li>
-              <Link
-                href={{ pathname, search: '?modal=1' }}
-                className='block px-4 py-2 font-bold uppercase transition-colors'
-              >
-                {t('contact')}
-              </Link>
-            </li>
           </ul>
         </nav>
+
+        {/* Bottom: CTA + toggles */}
+        <div className='flex flex-col gap-5 p-6 pt-8'>
+          <ContactCTA />
+
+          <div className='flex items-center gap-5'>
+            <DarkModeToggle />
+            <span className='text-foreground/20'>|</span>
+            <LanguageToggle />
+          </div>
+        </div>
       </div>
     </>
-  );
-}
-
-function MenuItem({
-  children,
-  href,
-}: {
-  children: React.ReactNode;
-  href: string;
-}) {
-  return (
-    <li>
-      <Link
-        href={href}
-        className='block px-4 py-2 font-bold uppercase transition-colors'
-      >
-        {children}
-      </Link>
-    </li>
   );
 }

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -23,5 +23,8 @@
   "send": "Send",
   "readMoreAbout": "Read more about \"{{title}}\"",
   "copyToClipboard": "Copy to clipboard",
-  "changeLanguage": "Change language"
+  "changeLanguage": "Change language",
+  "openMenu": "Open menu",
+  "closeMenu": "Close menu",
+  "mainMenu": "Main menu"
 }

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -24,5 +24,8 @@
   "send": "Enviar",
   "readMoreAbout": "Leer más sobre \"{{title}}\"",
   "copyToClipboard": "Copiar al portapapeles",
-  "changeLanguage": "Cambiar idioma"
+  "changeLanguage": "Cambiar idioma",
+  "openMenu": "Abrir menú",
+  "closeMenu": "Cerrar menú",
+  "mainMenu": "Menú Principal"
 }


### PR DESCRIPTION
## Summary

- **Mobile menu redesign**: replaces the generic `Bars3Icon` hamburger with a custom asymmetric 3-line icon (22/16/10px widths, right-aligned). The overlay is now a full-screen opacity fade instead of a slide-from-top, with the logo + SVG close button at the top, large nav items (28px, `font-light`) separated by `border-b`, and the Contact CTA + dark/language toggles moved inside the overlay at the bottom
- **Button hover fill**: CTA and form submit buttons now invert on hover — transparent background fills with `bg-zinc-900` / `bg-foreground` and text flips to contrast color
- **Footer logo hover**: removed accent color (`hover:text-primary`), now dims to `text-foreground/40`
- **Contact form dark mode inputs**: fixed `dark:bg-white dark:text-black` → `dark:bg-transparent dark:text-foreground dark:border-foreground/30`
- **i18n**: added `openMenu`, `closeMenu`, `mainMenu` keys to `en` and `es` locales
- **CLAUDE.md**: added Design System section documenting palette intent, typography rules, hover patterns, and key component conventions

## Test plan

- [x] Mobile viewport: hamburger icon renders as 3 asymmetric lines; tapping opens full-screen overlay with logo, nav items, CTA, and toggles
- [x] Overlay closes on logo click, nav item click, and X button
- [x] Desktop: menu unchanged (hamburger hidden at `md:`)
- [x] CTA button and contact form submit button fill on hover in both light and dark mode
- [x] Footer logo dims on hover (no red/blue accent)
- [x] Contact form inputs render correctly in dark mode (not white-on-dark)
- [x] Both ES and EN locales work without missing key warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)