### PR TITLE
Fix blog slider card links not navigating

### DIFF
--- a/components/blog/slider.tsx
+++ b/components/blog/slider.tsx
@@ -41,21 +41,33 @@ export default function BlogSlider({ posts }: { posts: PostItem[] }) {
 
   // ── Drag / swipe state ────────────────────────────────────────────────────
   const isDragging = useRef(false);
+  const hasDragged = useRef(false);
   const startX = useRef(0);
   const [dragOffset, setDragOffset] = useState(0);
   const [enableTransition, setEnableTransition] = useState(true);
 
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     isDragging.current = true;
+    hasDragged.current = false;
     startX.current = e.clientX;
     setEnableTransition(false);
-    // Capture so we still receive events if the pointer leaves the element
-    e.currentTarget.setPointerCapture(e.pointerId);
   };
 
   const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!isDragging.current) return;
-    setDragOffset(e.clientX - startX.current);
+    const offset = e.clientX - startX.current;
+    setDragOffset(offset);
+    if (Math.abs(offset) > 5) {
+      hasDragged.current = true;
+    }
+  };
+
+  const handleClickCapture = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (hasDragged.current) {
+      e.preventDefault();
+      e.stopPropagation();
+      hasDragged.current = false;
+    }
   };
 
   const commitDrag = () => {
@@ -112,6 +124,7 @@ export default function BlogSlider({ posts }: { posts: PostItem[] }) {
         onPointerMove={handlePointerMove}
         onPointerUp={commitDrag}
         onPointerLeave={commitDrag}
+        onClickCapture={handleClickCapture}
       >
         <div
           className={


### PR DESCRIPTION
## Summary

- Removes `setPointerCapture` from the slider's `handlePointerDown` — pointer capture was routing all pointer events (including the synthesized `click`) to the slider div instead of the child `<Link>` elements, so card titles and "Read More" buttons never fired navigation
- Adds a `hasDragged` ref that becomes `true` once pointer movement exceeds 5 px
- Adds `onClickCapture` on the slider container to block accidental link navigation at the end of a real drag gesture

## Test plan

- [x] Click a card title on the homepage → navigates to the blog post
- [x] Click "Read More" on a card → navigates to the blog post
- [x] Drag the slider left/right → paginates without navigating
- [x] Run `pnpm test` — Playwright suite passes

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)